### PR TITLE
Remote Admin path examples for Hugo are misleading

### DIFF
--- a/hugo/content/docs/editing/remote-admin.md
+++ b/hugo/content/docs/editing/remote-admin.md
@@ -33,7 +33,7 @@ The Remote Admin is deployed as a static HTML page, so be sure you deploy it to 
 
 ### Examples
 
-* In Hugo, this is `/static/admin`
+* In Hugo, this is `/static/admin` or just `admin`
 * In Jekyll, this is `/admin/`
 
 ## Deploying the Remote Admin


### PR DESCRIPTION
In my environment, using `/static/admin` puts index.html in `/static/admin/admin`, which is wrong.  Using just `admin` works.  My environment is Hugo 0.41 and Git on Bitbucket.  It looks like this path might be taken as relative to `/static/` for Hugo but that doesn't entirely explain the first behavior, so the code must be doing something a bit more complex.